### PR TITLE
[codex] Add quarterly pulse handbook page

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -21,6 +21,7 @@ Use this section as the operational source of truth for employees. Keep pages pr
 - [AI & Experimentation](/docs/ai-and-experimentation/)
 - [Communication & Meetings](/docs/communication-and-meetings/)
 - [Growth & Feedback](/docs/growth-and-feedback/)
+- [Quarterly Pulse](/docs/quarterly-pulse/)
 - [People Policies](/docs/people-policies/)
 
 ## Money, leave, and travel

--- a/content/docs/growth-and-feedback.md
+++ b/content/docs/growth-and-feedback.md
@@ -3,20 +3,21 @@ title = "Growth & Feedback"
 date = 2026-03-16T08:32:00+01:00
 weight = 55
 kicker = "Development"
-lead = "Growth at Helixiora is continuous: clear priorities, regular feedback, and practical development support."
-description = "Check-ins, goals, feedback culture, development support, and role growth process."
+lead = "Growth at Helixiora is continuous: clear priorities, regular 1:1s, Quarterly Pulse, and practical development support."
+description = "Check-ins, Quarterly Pulse, goals, feedback culture, development support, and role growth process."
 owner = "people"
 applies_to = "All employees and contractors"
 +++
 
 ## What this page is for
 
-This page explains how performance, development, and role growth work in practice, and complements [People Policies](/docs/people-policies/).
+This page explains how performance, development, and role growth work in practice. It is the overview page for feedback and development, while [Quarterly Pulse](/docs/quarterly-pulse/) explains the quarterly review process in detail.
 
 ## What you should do
 
 - Align on priorities and outcomes with your review owner or the leadership team.
 - Attend regular check-ins and bring concrete progress/blockers.
+- Complete Quarterly Pulse when it is sent to you and discuss the results in your next 1:1.
 - Ask for feedback early and give feedback constructively.
 - Use available learning support to build role-relevant capability.
 - Track impact and scope changes when discussing role growth.
@@ -29,9 +30,19 @@ Helixiora keeps this lightweight on purpose because the team is still small.
 
 Regular 1:1s with your review owner are the main rhythm for feedback, coaching, and development planning. Use them to discuss priorities, blockers, performance, and growth.
 
-### Reviews
+### Quarterly Pulse
 
-We aim to do formal reviews once per quarter. In practice, timing can move a little when delivery work gets in the way, but the expectation is that feedback should stay regular and not disappear for long stretches.
+Our formal quarterly review rhythm is [Quarterly Pulse](/docs/quarterly-pulse/).
+
+On the third Monday of the first month of each quarter, you receive a Slack DM with a link to a short Google Form. Your manager fills out the same form about your work, and the results are discussed in your next scheduled 1:1.
+
+Quarterly Pulse focuses on three things:
+
+- How you are doing
+- Job fit
+- Culture fit
+
+The point is to catch drift early. If your view and your manager's view match, the conversation can focus on what is working and what comes next. If they do not match, the mismatch is the useful part: it shows where expectations, support, role fit, or communication need attention.
 
 ### Raises and promotions
 
@@ -45,18 +56,24 @@ We do not currently have a fixed learning budget or a formal company-wide compet
 
 Leadership currently owns day-to-day coaching, regular 1:1s, and case-by-case raises and promotions.
 
+The People lead owns the Quarterly Pulse process. Managers own reviewing responses and using the next 1:1 to follow up properly.
+
 ## Where to go in the tool stack
 
 - Calendar for 1:1 cadence and review scheduling
+- Slack and Google Forms for Quarterly Pulse
 - Shared docs or notes for written feedback and follow-up
 - People lead (Robin) or your review owner for any learning or development request
 
 ## What happens if something goes wrong
 
-If expectations feel unclear, ask your review owner or the People lead to write down what good performance looks like in your role. If regular check-ins or reviews are slipping, raise it directly instead of letting it drift.
+If expectations feel unclear, ask your review owner or the People lead to write down what good performance looks like in your role.
+
+If regular check-ins or Quarterly Pulse follow-up conversations are slipping, raise it directly instead of letting it drift. The form only matters if it leads to a useful conversation.
 
 ## Related pages
 
 - [How We Work](/docs/how-we-work/)
 - [Communication & Meetings](/docs/communication-and-meetings/)
+- [Quarterly Pulse](/docs/quarterly-pulse/)
 - [People Policies](/docs/people-policies/)

--- a/content/docs/quarterly-pulse.md
+++ b/content/docs/quarterly-pulse.md
@@ -1,0 +1,111 @@
++++
+title = "Quarterly Pulse"
+date = 2026-05-12T09:00:00+02:00
+weight = 56
+kicker = "Development"
+lead = "Quarterly Pulse is our lightweight review rhythm for staying aligned on role fit, growth, performance, and happiness."
+description = "Quarterly Pulse cadence, questions, manager mirror review, 1:1 discussion, and why Helixiora uses it."
+owner = "people"
+applies_to = "All employees and contractors"
++++
+
+## What this page is for
+
+This page explains the Quarterly Pulse: our lightweight quarterly review process.
+
+At our size, we do not need a 40-page HR manual. We do need to make sure no one is drifting. Quarterly Pulse helps you, your manager, and leadership stay aligned on your role, your growth, your performance, and how you are feeling at Helixiora.
+
+## What you should do
+
+- Complete the Quarterly Pulse form when Slack sends it to you.
+- Answer the open question with enough detail to be useful.
+- Be honest about job fit, culture fit, and where support is missing.
+- Bring the results into your next 1:1 and be ready to discuss mismatches.
+- Treat the process as a way to catch drift early, not as a once-a-year performance verdict.
+
+## How the cadence works
+
+Quarterly Pulse is automated so it does not become a distraction from the work.
+
+### Trigger
+
+On the third Monday of the first month of every quarter, you receive a Slack DM with a link to the Google Form.
+
+That means the expected months are January, April, July, and October.
+
+### Time
+
+The form should take about 10 minutes.
+
+### Manager mirror
+
+Your manager fills out the same form about your work for the same quarter. This gives both sides a direct comparison before the follow-up conversation.
+
+## What the form asks
+
+Quarterly Pulse focuses on three areas.
+
+### How are you doing?
+
+This should not be answered with only "good" or "fine."
+
+Take a few minutes to explain how you are actually doing. Include anything that helps your manager understand energy level, workload, motivation, friction, stress, confidence, or where you need support.
+
+The form may use a minimum character count for this question to push for at least one useful sentence.
+
+### Job Fit
+
+Scale: 1-10
+
+Question: How much do your current projects align with your core strengths?
+
+A high score means your current work is making good use of what you are strongest at. A low score means there may be a mismatch between your strengths, your assignment, and what the company currently needs from you.
+
+### Culture Fit
+
+Scale: 1-5
+
+Question: How much do you feel you have lived our team values this quarter?
+
+This is about observed behavior and contribution to the way Helixiora works, not personality fit.
+
+## What happens in the 1:1
+
+Once the forms are in, your manager reviews your answers alongside their own. The results are then discussed in your next scheduled 1:1.
+
+If the scores match, the conversation can move quickly to what is working, what should continue, and what comes next.
+
+If the scores do not match, the mismatch becomes the main topic. For example, if you score Job Fit as a 10 and your manager scores it as a 6, or the other way around, that gap is important. The goal is to understand why both views differ and what needs to change.
+
+## Why we do this
+
+We want to catch drift early.
+
+If you are unhappy, if expectations are unclear, or if your current work is no longer a good match for your strengths, we want to know within weeks rather than discovering it during an annual review a year later.
+
+Quarterly Pulse is there to make support more timely and specific. It gives us a regular point to check whether the role, the work, the expectations, and the person are still aligned.
+
+## Who owns or approves it
+
+The People lead owns the Quarterly Pulse process. Managers own reviewing responses and using the next 1:1 to follow up properly.
+
+## Where to go in the tool stack
+
+- Slack for the automated quarterly prompt
+- Google Forms for the Quarterly Pulse form
+- Calendar for the follow-up 1:1
+- Shared notes if specific actions or expectations need to be written down
+
+## What happens if something goes wrong
+
+If you do not receive the form when expected, tell your manager or the People lead.
+
+If the follow-up conversation does not happen, raise it in your next 1:1. The form only matters if it leads to a useful conversation.
+
+If the form surfaces a serious concern, your manager or the People lead should agree on a concrete next step rather than leaving it as general feedback.
+
+## Related pages
+
+- [Growth & Feedback](/docs/growth-and-feedback/)
+- [Communication & Meetings](/docs/communication-and-meetings/)
+- [People Policies](/docs/people-policies/)


### PR DESCRIPTION
## Summary
- add a Quarterly Pulse handbook page with cadence, questions, manager mirror review, and 1:1 follow-up
- update Growth & Feedback to reference Quarterly Pulse as the formal quarterly review rhythm
- link Quarterly Pulse from the handbook docs hub

## Validation
- hugo --minify