### PR TITLE
[codex] Publish quarterly pulse page immediately

### DIFF
--- a/content/docs/quarterly-pulse.md
+++ b/content/docs/quarterly-pulse.md
@@ -1,6 +1,6 @@
 +++
 title = "Quarterly Pulse"
-date = 2026-05-12T09:00:00+02:00
+date = 2026-05-11T22:00:00+02:00
 weight = 56
 kicker = "Development"
 lead = "Quarterly Pulse is our lightweight review rhythm for staying aligned on role fit, growth, performance, and happiness."


### PR DESCRIPTION
## Summary
- move the Quarterly Pulse page date out of the future so Hugo publishes it immediately

## Root cause
Hugo excludes future-dated content by default. The page was dated 2026-05-12T09:00:00+02:00, but the Pages deploy happened earlier than that timestamp, so /docs/quarterly-pulse/ was not generated.

## Validation
- hugo --minify
- confirmed public/docs/quarterly-pulse/index.html is generated