### PR TITLE
[codex] Update handbook policy guidance

### DIFF
--- a/content/docs/ai-and-experimentation.md
+++ b/content/docs/ai-and-experimentation.md
@@ -1,6 +1,6 @@
 +++
 title = "AI & Experimentation"
-date = 2026-03-16T09:05:00+01:00
+date = 2026-05-12T09:00:00+02:00
 weight = 16
 kicker = "Company DNA"
 lead = "Helixiora expects people to keep looking for the next best thing in AI: experiment continuously, improve how you work, and use judgment on cost, security, and customer context."
@@ -52,6 +52,7 @@ Experimentation does not override common sense.
 
 - Follow client restrictions, NDAs, and data-handling requirements.
 - Do not paste sensitive company or client material into tools that are not appropriate for that data.
+- Follow the customer's AI policy when working in a customer environment, even if Helixiora's internal policy would be more permissive.
 - If a client context makes AI usage unclear, ask before using it.
 
 For the baseline security rules, also read [Security & Data Handling](/docs/security-and-data-handling/).
@@ -66,9 +67,18 @@ Shadow AI means using AI tools, agents, plugins, or automations in ways that byp
 - You do need to raise it before using a new AI tool with sensitive company data, client data, source code, inboxes, document stores, or recurring paid usage.
 - Do not connect unreviewed AI tools to company or client systems just because the setup is easy.
 - Do not hide AI-assisted workflows when a client, contract, or internal process requires disclosure or review.
+- Do not use AI tools to make employment, customer, financial, legal, or similarly material decisions without human review and clear accountability.
 - If you notice undeclared AI tooling creating risk, raise it quickly so the team can review it and either approve it, constrain it, or stop using it.
 
 Undisclosed or policy-bypassing AI use is treated as a security and conduct issue, not as healthy experimentation.
+
+## AI regulation awareness
+
+Helixiora is not trying to turn day-to-day experimentation into a compliance bureaucracy. Still, EU AI rules are now part of the operating context.
+
+Everyone using AI at work should understand the basics: prohibited AI practices are not allowed, customer policies take precedence in customer environments, and higher-risk uses need more care than ordinary productivity assistance.
+
+If you are building or deploying AI for a customer, especially where the system could affect people, access, money, employment, education, safety, or legal rights, involve the Technology lead early so the work can be checked against the customer policy and applicable regulatory expectations.
 
 ## Share what you learn
 

--- a/content/docs/local/netherlands.md
+++ b/content/docs/local/netherlands.md
@@ -1,6 +1,6 @@
 +++
 title = "Netherlands Appendix"
-date = 2026-03-16T08:37:00+01:00
+date = 2026-05-12T09:00:00+02:00
 weight = 210
 kicker = "Local"
 lead = "Local Dutch employment details that complement the global handbook."
@@ -31,9 +31,11 @@ We employ in the Netherlands through these forms:
 2. 0-hours contracts.
 3. Internships with a monthly internship fee of EUR 500.
 
-## Dutch public holidays (official)
+## Dutch public holidays
 
-We follow official Dutch public holidays.
+Helixiora treats official Dutch public holidays as paid days off for Netherlands employees.
+
+Dutch law does not automatically make every official public holiday a paid day off for every employee. This is a Helixiora employment policy for the Netherlands setup, subject to the employment contract and applicable law.
 
 Reference: Dutch government public holiday overview at [Rijksoverheid](https://www.rijksoverheid.nl/onderwerpen/feestdagen).
 
@@ -67,8 +69,8 @@ Reference: Dutch government public holiday overview at [Rijksoverheid](https://w
 
 ## Sick leave by contract type
 
-- 0-hours contract: if you are sick, there is no pay for those hours.
-- Contract-based employment (including full-time staff): sick leave remains paid in line with the contract.
+- 0-hours contract: sick pay depends on whether hours had already been accepted or scheduled, the contract, and Dutch law. If this applies to you, contact the People lead so the case is handled correctly.
+- Contract-based employment (including full-time staff): sick leave remains paid in line with the contract and Dutch law.
 
 For background on call-based contracts (including 0-hours structures), see the Dutch government guidance on [oproepcontracten](https://www.rijksoverheid.nl/onderwerpen/arbeidsovereenkomst-en-cao/vraag-en-antwoord/wat-is-een-oproepcontract).
 

--- a/content/docs/people-policies.md
+++ b/content/docs/people-policies.md
@@ -1,6 +1,6 @@
 +++
 title = "People Policies"
-date = 2026-03-16T08:33:00+01:00
+date = 2026-05-12T09:00:00+02:00
 weight = 60
 kicker = "Policies"
 lead = "This page summarizes core people policies in plain language and points to the right escalation route when issues arise."
@@ -22,7 +22,7 @@ Know and follow policies on:
 - Conflicts of interest and disclosure expectations
 - Grievance and escalation pathways
 - Disciplinary consequences for serious or repeated policy breaches
-- Whistleblowing route (if applicable)
+- Internal reporting route for serious integrity or whistleblowing concerns
 
 ## Reporting route
 
@@ -37,6 +37,19 @@ Use that same routing for:
 - interpersonal grievances or behavior issues
 - conflicts of interest and disclosure questions
 - serious integrity or whistleblowing concerns
+
+## Whistleblowing and serious integrity concerns
+
+Helixiora is currently a small company below the 50-person threshold and is not operating in a regulated sector that requires a formal internal whistleblowing procedure at smaller size.
+
+Even so, serious integrity concerns should have a clear internal route:
+
+- Report the concern to the People lead (Robin), or to the Technology lead (Walter) if that route is not appropriate.
+- Include the facts, dates, people or systems involved, and any supporting context you can safely share.
+- Concerns are handled confidentially as far as practical.
+- Retaliation for raising a concern in good faith is not acceptable.
+
+If Helixiora grows past the relevant threshold or enters a regulated sector where a formal procedure is required, this page must be updated before relying on this lightweight route.
 
 ## Disciplinary process
 

--- a/content/docs/time-off.md
+++ b/content/docs/time-off.md
@@ -1,6 +1,6 @@
 +++
 title = "Time Off & Holidays"
-date = 2026-03-16T08:05:00+01:00
+date = 2026-05-12T09:00:00+02:00
 weight = 20
 kicker = "Leave"
 lead = "Employees should be able to answer two questions quickly: how much leave they get, and exactly how they request it."
@@ -16,7 +16,7 @@ Helixiora uses an unlimited paid holiday leave approach, based on responsible pl
 | Leave type | Policy |
 | --- | --- |
 | Annual leave | Unlimited paid leave, planned with the People lead |
-| Public holidays | Follow location-specific handling in local appendices |
+| Public holidays | Follow location-specific handling in local appendices; Dutch official public holidays are paid days off for Netherlands employees |
 | Planning expectation | Balance team coverage and customer commitments |
 | Approval model | Submit and agree leave in advance where possible |
 


### PR DESCRIPTION
## Summary
- Clarify that Dutch official public holidays are paid days off for Netherlands employees
- Reword Netherlands 0-hours sick leave guidance to defer to scheduled hours, contracts, and Dutch law
- Add lightweight serious-integrity reporting guidance for the current small-company setup
- Update AI guidance around customer policy precedence, human review, and EU AI regulation awareness

## Validation
- git diff --check
- hugo --gc --minify --cacheDir /private/tmp/hugo-cache-handbook